### PR TITLE
Remove extra quotes from the user agent field

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,7 @@ http {
         '"bytes_sent":"$bytes_sent",'
         '"body_bytes_sent":"$body_bytes_sent",'
         '"referer":"$http_referer",'
-        '"user_agent":""$http_user_agent"",'
+        '"user_agent":"$http_user_agent",'
         '"upstream_addr":"$upstream_addr",'
         '"upstream_status":"$upstream_status",'
         '"request_time":"$request_time",'


### PR DESCRIPTION
The extra set of double quotes can break JSON parsing downstream