### PR TITLE
chore(base): update base image to 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM neighborhoods/nginx-auth-ldap:1.0
+FROM neighborhoods/nginx-auth-ldap:1.2.0
 
 COPY setup.sh /setup.sh
 RUN /setup.sh


### PR DESCRIPTION
Going to make a temp tag with jbarno to pull to verify this plays nice with ldap for retsmd before merging cutting a release.

Also @rjackson90 I discovered this while sleuthing:
https://hub.docker.com/layers/neighborhoods/nginx-extra/gzip-test/images/sha256-cdc3ad364a912433e1415cdae2f722478cd8ef142f61f78b54700d65a9b6d951?context=explore
